### PR TITLE
Add rx-scoreboard Medicare drug spending dashboard

### DIFF
--- a/rx-scoreboard/.gitignore
+++ b/rx-scoreboard/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/rx-scoreboard/LICENSE
+++ b/rx-scoreboard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ChatGPT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rx-scoreboard/README.md
+++ b/rx-scoreboard/README.md
@@ -1,0 +1,51 @@
+# RX Scoreboard
+
+A fully static "big board" visualizing U.S. Medicare drug spending with extrapolated live counters derived from CMS Part B and Part D drug spending workbooks plus NHE Table 01.
+
+## Quickstart
+1. **Create a virtual environment**
+   ```bash
+   python3 -m venv .venv && source .venv/bin/activate
+   ```
+2. **Install ETL dependencies**
+   ```bash
+   pip install pandas openpyxl
+   ```
+3. **Run the ETL pipeline** (supply your own downloaded files)
+   ```bash
+   python etl/prep.py \
+     --partd "/mnt/data/DSD_PTD_RY25_DYT23_Web - 250415.xlsx" \
+     --partb "/mnt/data/DSD_PTB_RY25_P06_V10_DYT23_WebExport - 250430.xlsx" \
+     --nhe "/mnt/data/Table 01 National Health Expenditures; Aggregate and Per Capita Amounts.xlsx"
+   ```
+4. **Open the scoreboard**
+   ```
+   open index.html  # or double-click the file
+   ```
+
+If you need to target a different report year, append `--year 2023` (for example). Use `--outdir` to emit JSON to a different folder.
+
+## Scope & methodology
+- Covers **Medicare Part D (retail prescription)** and **Medicare Part B (physician-administered drugs)** only.
+- "Live" counters are honest extrapolations: the latest full-year totals are pro-rated by the elapsed seconds in the selected calendar year (if the year has already ended, totals stay fixed).
+- National health expenditure (NHE) retail prescription drug totals provide **contextual headlines only**; they are not blended into Medicare calculations.
+- Drug names, spending, claims, and beneficiary fields mirror the CMS data dictionary naming (`Brnd_Name`, `Gnrc_Name`, `Tot_Spndng_YYYY`, `Tot_Clms_YYYY`, `Tot_Benes_YYYY`).
+
+## Column mapping cribsheet
+The ETL looks for the following stems (case-insensitive, ignoring spaces/hyphens):
+
+| Dataset | Required columns |
+| --- | --- |
+| Part D | `Brnd_Name`, `Gnrc_Name`, `Tot_Spndng_YYYY`, `Tot_Clms_YYYY`, `Tot_Benes_YYYY` |
+| Part B | `Brnd_Name`, `Gnrc_Name`, `HCPCS_Desc`, `Tot_Spndng_YYYY`, `Tot_Clms_YYYY`, `Tot_Benes_YYYY` |
+
+A prior-year spending column (`Tot_Spndng_(YYYY-1)`) is used when present to compute year-over-year changes.
+
+## Troubleshooting
+- **Missing columns**: The script lists close matches when a required column stem is absent. Verify that your workbooks come directly from CMS and that the requested year matches the suffix (e.g., `_2023`).
+- **Explicit year selection**: Use `--year` when your file contains multiple year columns but you want a specific one.
+- **Custom paths/output**: Supply absolute or relative paths to any downloaded files. Use `--outdir` to emit JSON elsewhere (defaults to `data/`).
+- **Empty dashboard**: If `/data` is empty, the frontend shows guidance on running the ETL instead of blank panels.
+
+## License
+MIT License — see [LICENSE](LICENSE).

--- a/rx-scoreboard/app.js
+++ b/rx-scoreboard/app.js
@@ -1,0 +1,840 @@
+(() => {
+  'use strict';
+  const YEAR_MIN = 2018;
+  const DATA_PREFIX = 'data/medicare_drugs_';
+  const NHE_PATH = 'data/nhe_retail_rx.json';
+  const svgNS = 'http://www.w3.org/2000/svg';
+
+  const USD_FULL = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  });
+  const USD_COMPACT = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 1,
+    notation: 'compact',
+  });
+  const USD_PER_SECOND = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+  });
+  const INT_COMPACT = new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  });
+  const INT_FULL = new Intl.NumberFormat('en-US');
+
+  const state = {
+    dataByYear: new Map(),
+    years: [],
+    year: null,
+    part: 'both',
+    glp1Only: false,
+    nhe: null,
+  };
+
+  const elements = {
+    yearSelect: document.getElementById('yearSelect'),
+    partToggle: document.getElementById('partToggle'),
+    glp1: document.getElementById('glp1Only'),
+    heroSection: document.getElementById('hero'),
+    heroTotal: document.getElementById('heroTotal'),
+    heroRate: document.getElementById('heroRate'),
+    heroContext: document.getElementById('heroContext'),
+    topList: document.getElementById('topDrugsList'),
+    moversList: document.getElementById('moversList'),
+    scatter: document.getElementById('scatterPlot'),
+    panels: document.querySelector('.panels'),
+    emptyState: document.getElementById('emptyState'),
+    tooltipLayer: document.getElementById('tooltip'),
+  };
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  let tooltipBubble = null;
+  let rafId = null;
+  let lastFrame = null;
+
+  class AnimatedNumber {
+    constructor(el, formatter) {
+      this.el = el;
+      this.formatter = formatter;
+      this.value = 0;
+      this.rate = 0;
+      this.limit = Infinity;
+      this.lastText = '';
+    }
+
+    update({ value, rate, limit }) {
+      if (!Number.isFinite(value)) {
+        value = 0;
+      }
+      this.limit = Number.isFinite(limit) ? limit : Infinity;
+      this.value = Math.min(value, this.limit);
+      this.rate = Number.isFinite(rate) ? rate : 0;
+      this.render();
+      scheduleAnimation();
+    }
+
+    stop() {
+      this.rate = 0;
+    }
+
+    shouldAnimate() {
+      return (
+        !prefersReducedMotion.matches &&
+        !document.hidden &&
+        this.rate !== 0 &&
+        this.value < this.limit
+      );
+    }
+
+    tick(delta) {
+      if (!this.shouldAnimate()) {
+        return this.shouldAnimate();
+      }
+      const next = Math.min(this.limit, this.value + this.rate * delta);
+      this.value = next;
+      if (this.value >= this.limit) {
+        this.value = this.limit;
+      }
+      this.render();
+      return this.shouldAnimate();
+    }
+
+    render() {
+      const text = this.formatter(this.value);
+      if (text !== this.lastText) {
+        this.el.textContent = text;
+        this.lastText = text;
+      }
+    }
+  }
+
+  const counterRegistry = new Map();
+  const animatedNumbers = new Set();
+
+  function getCounter(el, formatter) {
+    if (counterRegistry.has(el)) {
+      const existing = counterRegistry.get(el);
+      existing.formatter = formatter;
+      return existing;
+    }
+    const counter = new AnimatedNumber(el, formatter);
+    counterRegistry.set(el, counter);
+    animatedNumbers.add(counter);
+    return counter;
+  }
+
+  function releaseCounter(el) {
+    const counter = counterRegistry.get(el);
+    if (counter) {
+      counter.stop();
+      animatedNumbers.delete(counter);
+      counterRegistry.delete(el);
+    }
+  }
+
+  function hasActiveCounters() {
+    for (const counter of animatedNumbers) {
+      if (counter.shouldAnimate()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function scheduleAnimation() {
+    if (rafId !== null) {
+      return;
+    }
+    if (!hasActiveCounters()) {
+      return;
+    }
+    rafId = requestAnimationFrame(step);
+  }
+
+  function step(timestamp) {
+    rafId = null;
+    if (prefersReducedMotion.matches || document.hidden) {
+      lastFrame = null;
+      return;
+    }
+    if (lastFrame === null) {
+      lastFrame = timestamp;
+    }
+    const delta = (timestamp - lastFrame) / 1000;
+    lastFrame = timestamp;
+    let active = false;
+    for (const counter of animatedNumbers) {
+      if (counter.tick(delta)) {
+        active = true;
+      }
+    }
+    if (active) {
+      scheduleAnimation();
+    } else {
+      lastFrame = null;
+    }
+  }
+
+  const handleMotionChange = () => {
+    lastFrame = null;
+    if (!prefersReducedMotion.matches) {
+      scheduleAnimation();
+    }
+  };
+
+  if (typeof prefersReducedMotion.addEventListener === 'function') {
+    prefersReducedMotion.addEventListener('change', handleMotionChange);
+  } else if (typeof prefersReducedMotion.addListener === 'function') {
+    prefersReducedMotion.addListener(handleMotionChange);
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) {
+      lastFrame = null;
+      scheduleAnimation();
+    }
+  });
+
+  document.addEventListener('DOMContentLoaded', init);
+
+  async function init() {
+    const discoveredYears = await discoverYears();
+    if (discoveredYears.length === 0) {
+      showEmptyState(true);
+      await loadNhe();
+      return;
+    }
+    state.years = discoveredYears;
+    state.year = discoveredYears[0];
+    populateYearSelect();
+    bindControls();
+    await loadNhe();
+    update();
+  }
+
+  function showEmptyState(show) {
+    elements.emptyState.hidden = !show;
+    elements.heroSection.style.display = show ? 'none' : '';
+    elements.panels.style.display = show ? 'none' : '';
+  }
+
+  function populateYearSelect() {
+    const select = elements.yearSelect;
+    select.innerHTML = '';
+    state.years.forEach((year) => {
+      const option = document.createElement('option');
+      option.value = String(year);
+      option.textContent = String(year);
+      select.appendChild(option);
+    });
+    select.value = String(state.year);
+  }
+
+  function bindControls() {
+    elements.yearSelect.addEventListener('change', (event) => {
+      const value = Number.parseInt(event.target.value, 10);
+      if (!Number.isNaN(value)) {
+        state.year = value;
+        update();
+      }
+    });
+    elements.partToggle.addEventListener('change', (event) => {
+      if (event.target && event.target.name === 'part') {
+        state.part = event.target.value;
+        update();
+      }
+    });
+    elements.glp1.addEventListener('change', (event) => {
+      state.glp1Only = Boolean(event.target.checked);
+      update();
+    });
+  }
+
+  async function discoverYears() {
+    const years = [];
+    const currentYear = new Date().getFullYear();
+    for (let year = currentYear; year >= YEAR_MIN; year -= 1) {
+      const url = `${DATA_PREFIX}${year}.json`;
+      try {
+        const response = await fetch(url, { cache: 'no-cache' });
+        if (!response.ok) {
+          continue;
+        }
+        const data = await response.json();
+        if (Array.isArray(data)) {
+          state.dataByYear.set(year, data);
+          years.push(year);
+        }
+      } catch (error) {
+        // ignore network errors for discovery
+      }
+    }
+    years.sort((a, b) => b - a);
+    return years;
+  }
+
+  async function loadNhe() {
+    try {
+      const response = await fetch(NHE_PATH, { cache: 'no-cache' });
+      if (!response.ok) {
+        return;
+      }
+      const payload = await response.json();
+      if (payload && typeof payload === 'object') {
+        state.nhe = payload;
+      }
+    } catch (error) {
+      // swallow fetch errors so UI can still render
+    }
+  }
+
+  function update() {
+    const yearData = state.dataByYear.get(state.year) || [];
+    if (!yearData.length) {
+      showEmptyState(true);
+      return;
+    }
+    showEmptyState(false);
+    const filtered = yearData.filter((row) => {
+      const partMatch = state.part === 'both' || row.part === state.part;
+      const glpMatch = !state.glp1Only || row.is_glp1;
+      return partMatch && glpMatch;
+    });
+    const timeContext = computeTimeContext(state.year);
+    renderHero(filtered, timeContext);
+    renderTopDrugs(filtered, timeContext);
+    renderMovers(filtered);
+    renderScatter(filtered);
+  }
+
+  function computeTimeContext(year) {
+    const start = Date.UTC(year, 0, 1, 0, 0, 0);
+    const end = Date.UTC(year + 1, 0, 1, 0, 0, 0);
+    const yearSeconds = (end - start) / 1000;
+    const now = Date.now();
+    let elapsedSeconds = yearSeconds;
+    const currentYear = new Date().getFullYear();
+    if (year === currentYear) {
+      elapsedSeconds = Math.max(0, Math.min(yearSeconds, (now - start) / 1000));
+    } else if (year > currentYear) {
+      elapsedSeconds = 0;
+    }
+    return {
+      yearSeconds,
+      elapsedSeconds,
+      isCurrent: year === currentYear && elapsedSeconds < yearSeconds,
+    };
+  }
+
+  function renderHero(filtered, timeContext) {
+    const total = filtered.reduce((sum, row) => sum + (row.spend_total_usd || 0), 0);
+    const heroRateEl = elements.heroRate;
+    const heroContextEl = elements.heroContext;
+    if (total <= 0) {
+      releaseCounter(elements.heroTotal);
+      elements.heroTotal.textContent = '—';
+      heroRateEl.textContent = 'No spend data for this selection';
+    } else {
+      const rate = timeContext.yearSeconds > 0 && timeContext.isCurrent
+        ? total / timeContext.yearSeconds
+        : 0;
+      let initial = total;
+      if (timeContext.yearSeconds > 0) {
+        initial = timeContext.isCurrent
+          ? Math.min(total, rate * timeContext.elapsedSeconds)
+          : total;
+      }
+      const heroCounter = getCounter(elements.heroTotal, (value) => USD_FULL.format(value));
+      heroCounter.update({ value: initial, rate, limit: total });
+      if (rate > 0) {
+        heroRateEl.textContent = `≈ ${USD_PER_SECOND.format(rate)} per second`;
+      } else {
+        heroRateEl.textContent = `${USD_FULL.format(total)} full-year total`;
+      }
+    }
+    if (state.nhe && state.nhe.value_usd) {
+      heroContextEl.textContent = `NHE retail RX ${state.nhe.latest_year}: ${USD_FULL.format(state.nhe.value_usd)}`;
+    } else {
+      heroContextEl.textContent = '';
+    }
+  }
+
+  function renderTopDrugs(filtered, timeContext) {
+    const list = elements.topList;
+    clearContainer(list);
+    if (!filtered.length) {
+      const li = document.createElement('li');
+      li.textContent = 'No drugs match the current filters yet.';
+      li.style.color = 'var(--muted)';
+      list.appendChild(li);
+      return;
+    }
+    const sorted = [...filtered].sort(
+      (a, b) => (b.spend_total_usd || 0) - (a.spend_total_usd || 0),
+    );
+    const topFive = sorted.slice(0, 5);
+    topFive.forEach((row) => {
+      const li = document.createElement('li');
+      const nameWrap = document.createElement('div');
+      nameWrap.className = 'drug-name';
+      nameWrap.appendChild(createPartPill(row.part));
+      const nameSpan = document.createElement('span');
+      nameSpan.textContent = row.display_name;
+      nameWrap.appendChild(nameSpan);
+      if (row.is_glp1) {
+        const glpTag = document.createElement('span');
+        glpTag.className = 'pill glp1';
+        glpTag.textContent = 'GLP-1';
+        nameWrap.appendChild(glpTag);
+      }
+      const metrics = document.createElement('div');
+      metrics.className = 'drug-metrics';
+      const valueSpan = document.createElement('span');
+      valueSpan.className = 'drug-value';
+      valueSpan.setAttribute('data-counter', '');
+      valueSpan.title = `${USD_FULL.format(row.spend_total_usd)} in ${state.year}`;
+      const perSecond = timeContext.yearSeconds > 0 && timeContext.isCurrent
+        ? row.spend_total_usd / timeContext.yearSeconds
+        : 0;
+      let initial = row.spend_total_usd;
+      if (timeContext.yearSeconds > 0) {
+        initial = timeContext.isCurrent
+          ? Math.min(row.spend_total_usd, perSecond * timeContext.elapsedSeconds)
+          : row.spend_total_usd;
+      }
+      const counter = getCounter(valueSpan, (value) => USD_COMPACT.format(value));
+      counter.update({ value: initial, rate: perSecond, limit: row.spend_total_usd });
+      metrics.appendChild(valueSpan);
+      const rateText = document.createElement('small');
+      rateText.className = 'drug-rate';
+      if (perSecond > 0) {
+        rateText.textContent = `≈ ${USD_PER_SECOND.format(perSecond)} per sec`;
+      } else {
+        rateText.textContent = `${USD_FULL.format(row.spend_total_usd)} full-year`;
+      }
+      metrics.appendChild(rateText);
+      li.appendChild(nameWrap);
+      li.appendChild(metrics);
+      list.appendChild(li);
+    });
+  }
+
+  function renderMovers(filtered) {
+    const list = elements.moversList;
+    clearContainer(list);
+    if (!filtered.length) {
+      const li = document.createElement('li');
+      li.textContent = 'No matching data to compare yet.';
+      li.style.color = 'var(--muted)';
+      list.appendChild(li);
+      return;
+    }
+    const withPrev = filtered
+      .filter((row) => row.prev_spend_total_usd != null)
+      .map((row) => ({
+        row,
+        delta: row.spend_total_usd - row.prev_spend_total_usd,
+      }))
+      .sort((a, b) => (b.delta || 0) - (a.delta || 0));
+    const withoutPrev = filtered
+      .filter((row) => row.prev_spend_total_usd == null)
+      .sort((a, b) => (b.spend_total_usd || 0) - (a.spend_total_usd || 0));
+    const combined = [...withPrev.map((item) => item.row), ...withoutPrev].slice(0, 10);
+    combined.forEach((row) => {
+      const li = document.createElement('li');
+      const top = document.createElement('div');
+      top.className = 'row-top';
+      const name = document.createElement('div');
+      name.className = 'name';
+      name.appendChild(createPartPill(row.part));
+      const nameText = document.createElement('span');
+      nameText.textContent = row.display_name;
+      name.appendChild(nameText);
+      if (row.is_glp1) {
+        const glp = document.createElement('span');
+        glp.className = 'pill glp1';
+        glp.textContent = 'GLP-1';
+        name.appendChild(glp);
+      }
+      top.appendChild(name);
+      const deltaBadge = document.createElement('span');
+      const delta = row.prev_spend_total_usd != null
+        ? row.spend_total_usd - row.prev_spend_total_usd
+        : null;
+      if (delta != null) {
+        deltaBadge.className = 'delta-badge';
+        const sign = delta >= 0 ? '+' : '−';
+        deltaBadge.textContent = `${sign}${USD_FULL.format(Math.abs(delta))}`;
+        top.appendChild(deltaBadge);
+      }
+      li.appendChild(top);
+      const bottom = document.createElement('div');
+      bottom.className = 'row-bottom';
+      bottom.appendChild(makeMetaSpan('Spend', USD_FULL.format(row.spend_total_usd || 0)));
+      bottom.appendChild(makeMetaSpan('Claims', formatInt(row.claims)));
+      bottom.appendChild(makeMetaSpan('Beneficiaries', formatInt(row.beneficiaries)));
+      if (row.prev_spend_total_usd != null && row.prev_year != null) {
+        bottom.appendChild(
+          makeMetaSpan(
+            `Prev ${row.prev_year}`,
+            USD_FULL.format(row.prev_spend_total_usd),
+          ),
+        );
+      }
+      li.appendChild(bottom);
+      list.appendChild(li);
+    });
+  }
+
+  function renderScatter(filtered) {
+    const svg = elements.scatter;
+    hideTooltip();
+    while (svg.firstChild) {
+      svg.removeChild(svg.firstChild);
+    }
+    const width = 640;
+    const height = 420;
+    const margin = { top: 40, right: 30, bottom: 60, left: 80 };
+    const innerWidth = width - margin.left - margin.right;
+    const innerHeight = height - margin.top - margin.bottom;
+    const points = filtered
+      .map((row) => ({
+        row,
+        claims: Number(row.claims) || 0,
+        spend: Number(row.spend_total_usd) || 0,
+        unitCost: row.claims ? row.spend_total_usd / row.claims : 0,
+      }))
+      .filter((item) => item.claims > 0 && item.unitCost > 0 && item.spend > 0);
+
+    if (!points.length) {
+      const message = document.createElementNS(svgNS, 'text');
+      message.setAttribute('x', String(width / 2));
+      message.setAttribute('y', String(height / 2));
+      message.setAttribute('text-anchor', 'middle');
+      message.setAttribute('fill', 'var(--muted)');
+      message.setAttribute('font-size', '16');
+      message.textContent = 'Not enough claims data to plot yet.';
+      svg.appendChild(message);
+      return;
+    }
+
+    const maxClaims = niceCeil(Math.max(...points.map((p) => p.claims)));
+    const maxUnitCost = niceCeil(Math.max(...points.map((p) => p.unitCost)));
+    const maxSpend = Math.max(...points.map((p) => p.spend));
+    const xScale = (value) => margin.left + (value / maxClaims) * innerWidth;
+    const yScale = (value) => margin.top + (1 - value / maxUnitCost) * innerHeight;
+    const radiusScale = (spend) => {
+      const minRadius = 6;
+      const maxRadius = 26;
+      if (maxSpend <= 0) {
+        return minRadius;
+      }
+      const ratio = Math.sqrt(spend / maxSpend);
+      return minRadius + ratio * (maxRadius - minRadius);
+    };
+
+    const axisGroup = document.createElementNS(svgNS, 'g');
+    svg.appendChild(axisGroup);
+
+    const xAxis = document.createElementNS(svgNS, 'line');
+    xAxis.setAttribute('x1', String(margin.left));
+    xAxis.setAttribute('y1', String(height - margin.bottom));
+    xAxis.setAttribute('x2', String(width - margin.right));
+    xAxis.setAttribute('y2', String(height - margin.bottom));
+    xAxis.setAttribute('stroke', 'currentColor');
+    xAxis.setAttribute('stroke-opacity', '0.2');
+    axisGroup.appendChild(xAxis);
+
+    const yAxis = document.createElementNS(svgNS, 'line');
+    yAxis.setAttribute('x1', String(margin.left));
+    yAxis.setAttribute('y1', String(margin.top));
+    yAxis.setAttribute('x2', String(margin.left));
+    yAxis.setAttribute('y2', String(height - margin.bottom));
+    yAxis.setAttribute('stroke', 'currentColor');
+    yAxis.setAttribute('stroke-opacity', '0.2');
+    axisGroup.appendChild(yAxis);
+
+    const xStep = Math.max(1, Math.ceil(niceStep(maxClaims)));
+    let xTicks = 0;
+    let lastXValue = 0;
+    for (let value = 0; value <= maxClaims && xTicks < 8; value += xStep) {
+      const x = xScale(value);
+      const tick = document.createElementNS(svgNS, 'line');
+      tick.setAttribute('x1', String(x));
+      tick.setAttribute('x2', String(x));
+      tick.setAttribute('y1', String(height - margin.bottom));
+      tick.setAttribute('y2', String(height - margin.bottom + 8));
+      tick.setAttribute('stroke', 'currentColor');
+      tick.setAttribute('stroke-opacity', '0.3');
+      axisGroup.appendChild(tick);
+      const label = document.createElementNS(svgNS, 'text');
+      label.setAttribute('x', String(x));
+      label.setAttribute('y', String(height - margin.bottom + 24));
+      label.setAttribute('text-anchor', 'middle');
+      label.setAttribute('fill', 'currentColor');
+      label.setAttribute('font-size', '12');
+      label.textContent = value === 0 ? '0' : INT_COMPACT.format(value);
+      axisGroup.appendChild(label);
+      xTicks += 1;
+      lastXValue = value;
+    }
+    if (Math.abs(lastXValue - maxClaims) > xStep * 0.25) {
+      const x = xScale(maxClaims);
+      const tick = document.createElementNS(svgNS, 'line');
+      tick.setAttribute('x1', String(x));
+      tick.setAttribute('x2', String(x));
+      tick.setAttribute('y1', String(height - margin.bottom));
+      tick.setAttribute('y2', String(height - margin.bottom + 8));
+      tick.setAttribute('stroke', 'currentColor');
+      tick.setAttribute('stroke-opacity', '0.3');
+      axisGroup.appendChild(tick);
+      const label = document.createElementNS(svgNS, 'text');
+      label.setAttribute('x', String(x));
+      label.setAttribute('y', String(height - margin.bottom + 24));
+      label.setAttribute('text-anchor', 'middle');
+      label.setAttribute('fill', 'currentColor');
+      label.setAttribute('font-size', '12');
+      label.textContent = INT_COMPACT.format(maxClaims);
+      axisGroup.appendChild(label);
+    }
+
+    const yStep = niceStep(maxUnitCost);
+    let yTicks = 0;
+    let lastYValue = 0;
+    for (let value = 0; value <= maxUnitCost && yTicks < 8; value += yStep) {
+      const y = yScale(value);
+      const tick = document.createElementNS(svgNS, 'line');
+      tick.setAttribute('x1', String(margin.left - 8));
+      tick.setAttribute('x2', String(margin.left));
+      tick.setAttribute('y1', String(y));
+      tick.setAttribute('y2', String(y));
+      tick.setAttribute('stroke', 'currentColor');
+      tick.setAttribute('stroke-opacity', '0.3');
+      axisGroup.appendChild(tick);
+      const label = document.createElementNS(svgNS, 'text');
+      label.setAttribute('x', String(margin.left - 12));
+      label.setAttribute('y', String(y + 4));
+      label.setAttribute('text-anchor', 'end');
+      label.setAttribute('fill', 'currentColor');
+      label.setAttribute('font-size', '12');
+      label.textContent = value === 0 ? '0' : USD_COMPACT.format(value);
+      axisGroup.appendChild(label);
+      yTicks += 1;
+      lastYValue = value;
+    }
+    if (Math.abs(lastYValue - maxUnitCost) > yStep * 0.25) {
+      const y = yScale(maxUnitCost);
+      const tick = document.createElementNS(svgNS, 'line');
+      tick.setAttribute('x1', String(margin.left - 8));
+      tick.setAttribute('x2', String(margin.left));
+      tick.setAttribute('y1', String(y));
+      tick.setAttribute('y2', String(y));
+      tick.setAttribute('stroke', 'currentColor');
+      tick.setAttribute('stroke-opacity', '0.3');
+      axisGroup.appendChild(tick);
+      const label = document.createElementNS(svgNS, 'text');
+      label.setAttribute('x', String(margin.left - 12));
+      label.setAttribute('y', String(y + 4));
+      label.setAttribute('text-anchor', 'end');
+      label.setAttribute('fill', 'currentColor');
+      label.setAttribute('font-size', '12');
+      label.textContent = USD_COMPACT.format(maxUnitCost);
+      axisGroup.appendChild(label);
+    }
+
+    const xLabel = document.createElementNS(svgNS, 'text');
+    xLabel.setAttribute('x', String(margin.left + innerWidth / 2));
+    xLabel.setAttribute('y', String(height - 16));
+    xLabel.setAttribute('text-anchor', 'middle');
+    xLabel.setAttribute('fill', 'currentColor');
+    xLabel.setAttribute('font-size', '13');
+    xLabel.textContent = 'Claims (count)';
+    axisGroup.appendChild(xLabel);
+
+    const yLabel = document.createElementNS(svgNS, 'text');
+    yLabel.setAttribute('transform', `rotate(-90 ${margin.left - 50} ${margin.top + innerHeight / 2})`);
+    yLabel.setAttribute('x', String(margin.left - 50));
+    yLabel.setAttribute('y', String(margin.top + innerHeight / 2));
+    yLabel.setAttribute('text-anchor', 'middle');
+    yLabel.setAttribute('fill', 'currentColor');
+    yLabel.setAttribute('font-size', '13');
+    yLabel.textContent = 'Spend per claim (USD)';
+    axisGroup.appendChild(yLabel);
+
+    const legend = document.createElementNS(svgNS, 'g');
+    legend.setAttribute('transform', `translate(${width - margin.right - 140}, ${margin.top - 20})`);
+    const legendItems = [
+      { label: 'Part D', color: 'var(--part-d)' },
+      { label: 'Part B', color: 'var(--part-b)' },
+    ];
+    legendItems.forEach((item, index) => {
+      const group = document.createElementNS(svgNS, 'g');
+      group.setAttribute('transform', `translate(0, ${index * 20})`);
+      const circle = document.createElementNS(svgNS, 'circle');
+      circle.setAttribute('cx', '8');
+      circle.setAttribute('cy', '8');
+      circle.setAttribute('r', '6');
+      circle.setAttribute('fill', item.color);
+      group.appendChild(circle);
+      const label = document.createElementNS(svgNS, 'text');
+      label.setAttribute('x', '18');
+      label.setAttribute('y', '12');
+      label.setAttribute('fill', 'currentColor');
+      label.setAttribute('font-size', '12');
+      label.textContent = item.label;
+      group.appendChild(label);
+      legend.appendChild(group);
+    });
+    svg.appendChild(legend);
+
+    const bubblesGroup = document.createElementNS(svgNS, 'g');
+    svg.appendChild(bubblesGroup);
+
+    points.forEach((point) => {
+      const circle = document.createElementNS(svgNS, 'circle');
+      circle.setAttribute('cx', String(xScale(point.claims)));
+      circle.setAttribute('cy', String(yScale(point.unitCost)));
+      circle.setAttribute('r', String(radiusScale(point.spend)));
+      circle.setAttribute('fill', point.row.part === 'D' ? 'var(--part-d)' : 'var(--part-b)');
+      circle.setAttribute('fill-opacity', '0.7');
+      circle.setAttribute('stroke', 'rgba(0,0,0,0.08)');
+      circle.setAttribute('tabindex', '0');
+      circle.setAttribute('role', 'graphics-symbol');
+      circle.setAttribute('aria-label', `${point.row.display_name}: ${USD_FULL.format(point.row.spend_total_usd)} total, ${formatInt(point.row.claims)} claims`);
+      const show = (event) => {
+        const coords = event
+          ? { x: event.clientX + 12, y: event.clientY + 12 }
+          : rectCenter(circle.getBoundingClientRect());
+        showTooltip(
+          `<strong>${escapeHtml(point.row.display_name)}</strong>`
+            + `<div>${USD_FULL.format(point.row.spend_total_usd)} total</div>`
+            + `<div>${formatInt(point.row.claims)} claims</div>`
+            + `<div>${formatInt(point.row.beneficiaries)} beneficiaries</div>`,
+          coords,
+        );
+      };
+      circle.addEventListener('pointerenter', show);
+      circle.addEventListener('pointermove', show);
+      circle.addEventListener('pointerleave', hideTooltip);
+      circle.addEventListener('focus', () => show());
+      circle.addEventListener('blur', hideTooltip);
+      circle.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          hideTooltip();
+        }
+      });
+      bubblesGroup.appendChild(circle);
+    });
+  }
+
+  function niceCeil(value) {
+    if (!Number.isFinite(value) || value <= 0) {
+      return 1;
+    }
+    const exponent = Math.floor(Math.log10(value));
+    const factor = 10 ** exponent;
+    return Math.ceil(value / factor) * factor;
+  }
+
+  function niceStep(value) {
+    if (!Number.isFinite(value) || value <= 0) {
+      return 1;
+    }
+    const exponent = Math.floor(Math.log10(value));
+    const fraction = value / 10 ** exponent;
+    let niceFraction;
+    if (fraction <= 1) {
+      niceFraction = 0.2;
+    } else if (fraction <= 2) {
+      niceFraction = 0.5;
+    } else if (fraction <= 5) {
+      niceFraction = 1;
+    } else {
+      niceFraction = 2;
+    }
+    return niceFraction * 10 ** exponent;
+  }
+
+  function makeMetaSpan(label, value) {
+    const span = document.createElement('span');
+    span.textContent = `${label}: ${value}`;
+    return span;
+  }
+
+  function formatInt(value) {
+    if (value == null || Number.isNaN(value)) {
+      return '—';
+    }
+    return INT_FULL.format(value);
+  }
+
+  function clearContainer(container) {
+    const counters = container.querySelectorAll('[data-counter]');
+    counters.forEach((el) => releaseCounter(el));
+    container.innerHTML = '';
+  }
+
+  function createPartPill(part) {
+    const span = document.createElement('span');
+    span.className = `pill part-${part === 'D' ? 'd' : 'b'}`;
+    span.textContent = part === 'D' ? 'Part D' : 'Part B';
+    return span;
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function showTooltip(html, coords) {
+    if (!tooltipBubble) {
+      tooltipBubble = document.createElement('div');
+      tooltipBubble.className = 'bubble';
+      elements.tooltipLayer.appendChild(tooltipBubble);
+    }
+    tooltipBubble.innerHTML = html;
+    elements.tooltipLayer.hidden = false;
+    positionTooltip(coords);
+  }
+
+  function positionTooltip(coords) {
+    if (!tooltipBubble) return;
+    const bubble = tooltipBubble;
+    requestAnimationFrame(() => {
+      const rect = bubble.getBoundingClientRect();
+      let left = coords.x;
+      let top = coords.y;
+      if (left + rect.width + 16 > window.innerWidth) {
+        left = Math.max(12, window.innerWidth - rect.width - 16);
+      }
+      if (top + rect.height + 16 > window.innerHeight) {
+        top = Math.max(12, window.innerHeight - rect.height - 16);
+      }
+      bubble.style.left = `${left}px`;
+      bubble.style.top = `${top}px`;
+    });
+  }
+
+  function rectCenter(rect) {
+    return {
+      x: rect.left + rect.width + 12,
+      y: rect.top + rect.height / 2,
+    };
+  }
+
+  function hideTooltip() {
+    if (tooltipBubble) {
+      tooltipBubble.innerHTML = '';
+    }
+    elements.tooltipLayer.hidden = true;
+  }
+})();

--- a/rx-scoreboard/etl/README.md
+++ b/rx-scoreboard/etl/README.md
@@ -1,0 +1,43 @@
+# ETL Notes
+
+`prep.py` ingests the official CMS Medicare Part D and Part B drug spending public use files together with the National Health Expenditure (NHE) Table 01 workbook.
+
+## Column stems searched
+All matches are case-insensitive and ignore whitespace, underscores, and hyphens. The script trims column headers and tolerates Unicode spacing quirks.
+
+### Medicare Part D
+- `Brnd_Name`
+- `Gnrc_Name`
+- `Tot_Spndng_YYYY`
+- `Tot_Clms_YYYY`
+- `Tot_Benes_YYYY`
+
+### Medicare Part B
+- `Brnd_Name`
+- `Gnrc_Name`
+- `HCPCS_Desc`
+- `Tot_Spndng_YYYY`
+- `Tot_Clms_YYYY`
+- `Tot_Benes_YYYY`
+
+If a matching `Tot_Spndng_(YYYY-1)` column exists it is captured for year-over-year deltas.
+
+### NHE Table 01
+The script looks for the row whose first column contains both "retail" and "prescription" and for all four-digit column headers representing calendar years.
+
+## Usage examples
+
+Select a specific report year and a custom output directory:
+```bash
+python etl/prep.py \
+  --year 2023 \
+  --partd /path/to/partd.xlsx \
+  --partb /path/to/partb.xlsx \
+  --nhe /path/to/nhe_table01.xlsx \
+  --outdir /tmp/rx-json
+```
+
+Run with default year autodetection while emitting to the bundled `data/` folder:
+```bash
+python etl/prep.py --partd ~/Downloads/partd.xlsx --partb ~/Downloads/partb.xlsx --nhe ~/Downloads/nhe.xlsx
+```

--- a/rx-scoreboard/etl/prep.py
+++ b/rx-scoreboard/etl/prep.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""ETL for the RX Scoreboard project."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import pandas as pd
+
+GLP1_PATTERN = re.compile(
+    r"(semaglutide|tirzepatide|liraglutide|dulaglutide|exenatide|glp\s*-?\s*1|incretin)",
+    re.IGNORECASE,
+)
+
+
+class ColumnLookupError(RuntimeError):
+    """Raised when a required column is missing."""
+
+
+def sanitize_key(value: str) -> str:
+    """Normalize column headers for matching."""
+    return re.sub(r"[\s\-_]+", "", value.strip().lower())
+
+
+def find_column(
+    columns: Sequence[str],
+    stem: str,
+    year: Optional[int] = None,
+) -> Tuple[Optional[str], List[str]]:
+    """Return the matching column name, if any, and nearby suggestions."""
+    normalized = {col: sanitize_key(str(col)) for col in columns}
+    base_key = sanitize_key(stem)
+    suggestions = [col for col, key in normalized.items() if key.startswith(base_key)]
+
+    if year is None:
+        target = base_key
+        matches = [col for col, key in normalized.items() if key == target]
+    else:
+        target = f"{base_key}{year}"
+        matches = [
+            col
+            for col, key in normalized.items()
+            if key == target or key.startswith(target)
+        ]
+    if len(matches) > 1:
+        raise ColumnLookupError(
+            f"Multiple columns matched '{stem}'{f' for {year}' if year else ''}: {matches}"
+        )
+    if matches:
+        return matches[0], suggestions
+    return None, suggestions
+
+
+def require_column(
+    columns: Sequence[str],
+    stem: str,
+    dataset: str,
+    year: Optional[int] = None,
+) -> str:
+    column, suggestions = find_column(columns, stem, year=year)
+    if column is None:
+        suffix = f"_{year}" if year is not None else ""
+        hint = f" Similar columns: {', '.join(suggestions)}" if suggestions else ""
+        raise ColumnLookupError(
+            f"{dataset}: unable to locate column matching '{stem}{suffix}'.{hint}"
+        )
+    return column
+
+
+def to_float(value) -> Optional[float]:
+    if pd.isna(value):
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        cleaned = stripped.replace(",", "")
+        try:
+            return float(cleaned)
+        except ValueError:
+            return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def to_int(value) -> Optional[int]:
+    num = to_float(value)
+    if num is None:
+        return None
+    try:
+        return int(round(num))
+    except (ValueError, OverflowError):
+        return None
+
+
+def normalize_text(value) -> Optional[str]:
+    if pd.isna(value):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return re.sub(r"\s+", " ", text)
+
+
+def pick_display_name(row: pd.Series, columns: Sequence[str]) -> Optional[str]:
+    for col in columns:
+        if col is None:
+            continue
+        name = normalize_text(row.get(col))
+        if name:
+            return name
+    return None
+
+
+def extract_available_years(columns: Iterable[str], stem: str) -> List[int]:
+    base = sanitize_key(stem)
+    years: List[int] = []
+    for col in columns:
+        key = sanitize_key(str(col))
+        if base in key:
+            matches = re.findall(r"(19|20)\d{2}", key)
+            for match in matches:
+                year = int(match)
+                if year not in years:
+                    years.append(year)
+    return years
+
+
+def ensure_year_available(
+    part_label: str, columns: Sequence[str], stem: str, year: int
+) -> None:
+    column, _ = find_column(columns, stem, year=year)
+    if column is None:
+        available = extract_available_years(columns, stem)
+        available_str = ", ".join(str(y) for y in sorted(available)) or "none"
+        raise ColumnLookupError(
+            f"{part_label}: column for '{stem}_{year}' not found. Available years: {available_str}."
+        )
+
+
+def prepare_part(
+    df: pd.DataFrame,
+    year: int,
+    part_label: str,
+    dataset_name: str,
+) -> List[Dict[str, object]]:
+    columns = list(df.columns)
+    brand_col = require_column(columns, "Brnd_Name", dataset_name)
+    generic_col = require_column(columns, "Gnrc_Name", dataset_name)
+    hcpcs_col = None
+    if part_label == "B":
+        hcpcs_col = require_column(columns, "HCPCS_Desc", dataset_name)
+    spend_col = require_column(columns, "Tot_Spndng", dataset_name, year=year)
+    claims_col = require_column(columns, "Tot_Clms", dataset_name, year=year)
+    benes_col = require_column(columns, "Tot_Benes", dataset_name, year=year)
+
+    prev_year = year - 1
+    prev_col, _ = find_column(columns, "Tot_Spndng", year=prev_year)
+
+    records: List[Dict[str, object]] = []
+    for _, row in df.iterrows():
+        display_name = pick_display_name(row, (brand_col, generic_col, hcpcs_col))
+        if not display_name:
+            continue
+        spend = to_float(row.get(spend_col))
+        if spend is None or spend <= 0:
+            continue
+        claims = to_int(row.get(claims_col))
+        benes = to_int(row.get(benes_col))
+        prev_spend = to_float(row.get(prev_col)) if prev_col else None
+        record = {
+            "year": year,
+            "part": part_label,
+            "display_name": display_name,
+            "spend_total_usd": float(spend),
+            "claims": claims,
+            "beneficiaries": benes,
+            "prev_year": prev_year if prev_spend is not None else None,
+            "prev_spend_total_usd": float(prev_spend) if prev_spend is not None else None,
+            "is_glp1": bool(GLP1_PATTERN.search(display_name)),
+        }
+        records.append(record)
+    return records
+
+
+def process_nhe(nhe_path: Path) -> Dict[str, object]:
+    nhe_df = pd.read_excel(nhe_path, engine="openpyxl")
+    if nhe_df.empty:
+        raise RuntimeError("NHE workbook appears to be empty.")
+    nhe_df.columns = [str(col).strip() for col in nhe_df.columns]
+    first_col = nhe_df.columns[0]
+    mask = nhe_df[first_col].astype(str).str.contains("retail", case=False, na=False)
+    mask &= nhe_df[first_col].astype(str).str.contains("prescription", case=False, na=False)
+    target_rows = nhe_df[mask]
+    if target_rows.empty:
+        raise RuntimeError(
+            "Unable to locate a row containing both 'retail' and 'prescription' in NHE Table 01."
+        )
+    row = target_rows.iloc[0]
+    year_values: Dict[int, float] = {}
+    for col in nhe_df.columns[1:]:
+        key = str(col)
+        match = re.search(r"(19|20)\d{2}", key)
+        if not match:
+            continue
+        year = int(match.group(0))
+        value = to_float(row.get(col))
+        if value is None:
+            continue
+        year_values[year] = float(value)
+    if not year_values:
+        raise RuntimeError("No usable year columns were found in the NHE table.")
+    latest_year = max(year_values)
+    latest_value = year_values[latest_year]
+    series_years = sorted(year_values)[-5:]
+    series = [
+        {"year": year, "value_usd": float(year_values[year])}
+        for year in series_years
+    ]
+    return {
+        "latest_year": latest_year,
+        "value_usd": float(latest_value),
+        "series": series,
+    }
+
+
+def detect_year(partd_cols: Sequence[str], partb_cols: Sequence[str], explicit: Optional[int]) -> int:
+    if explicit is not None:
+        return explicit
+    years = set(extract_available_years(partd_cols, "Tot_Spndng"))
+    years.update(extract_available_years(partb_cols, "Tot_Spndng"))
+    if not years:
+        raise ColumnLookupError(
+            "Unable to detect a year suffix from Tot_Spndng columns in either workbook."
+        )
+    return max(years)
+
+
+def load_dataframe(path: Path) -> pd.DataFrame:
+    df = pd.read_excel(path, engine="openpyxl")
+    df.columns = [str(col).strip() for col in df.columns]
+    return df
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Prepare Medicare drug spending JSON extracts.")
+    parser.add_argument("--partd", required=True, help="Path to the Medicare Part D by drug workbook")
+    parser.add_argument("--partb", required=True, help="Path to the Medicare Part B by drug workbook")
+    parser.add_argument("--nhe", required=True, help="Path to the NHE Table 01 workbook")
+    parser.add_argument("--outdir", default=str(Path(__file__).resolve().parent.parent / "data"))
+    parser.add_argument("--year", type=int, help="Four-digit report year to extract")
+    args = parser.parse_args(argv)
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    partd_path = Path(args.partd)
+    partb_path = Path(args.partb)
+    nhe_path = Path(args.nhe)
+
+    partd_df = load_dataframe(partd_path)
+    partb_df = load_dataframe(partb_path)
+
+    year = detect_year(partd_df.columns, partb_df.columns, args.year)
+
+    ensure_year_available("Part D", partd_df.columns, "Tot_Spndng", year)
+    ensure_year_available("Part B", partb_df.columns, "Tot_Spndng", year)
+
+    d_records = prepare_part(partd_df, year, "D", "Part D")
+    b_records = prepare_part(partb_df, year, "B", "Part B")
+
+    if not d_records and not b_records:
+        raise RuntimeError(
+            f"No spending rows were extracted for year {year}. Check that the workbooks contain data for this year."
+        )
+
+    output_records = d_records + b_records
+    output_path = outdir / f"medicare_drugs_{year}.json"
+    with output_path.open("w", encoding="utf-8") as fh:
+        json.dump(output_records, fh, indent=2)
+
+    nhe_payload = process_nhe(nhe_path)
+    nhe_path_out = outdir / "nhe_retail_rx.json"
+    with nhe_path_out.open("w", encoding="utf-8") as fh:
+        json.dump(nhe_payload, fh, indent=2)
+
+    print(f"Wrote {len(output_records)} Medicare drug rows for {year} to {output_path}")
+    print(
+        f"Wrote NHE retail prescription series ({nhe_payload['latest_year']}) to {nhe_path_out}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except ColumnLookupError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/rx-scoreboard/index.html
+++ b/rx-scoreboard/index.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RX Scoreboard</title>
+    <link rel="stylesheet" href="style.css" />
+    <meta name="description" content="Live-style Medicare drug spending scoreboard, extrapolated from CMS data." />
+    <script defer src="app.js"></script>
+  </head>
+  <body>
+    <noscript>
+      <div class="noscript" role="status">
+        This experience needs JavaScript enabled to animate the live Medicare drug spending counters.
+      </div>
+    </noscript>
+    <div id="app" class="app-shell">
+      <header class="site-header" role="banner">
+        <div class="brand">
+          <h1>RX Scoreboard</h1>
+          <p class="subtitle">Real-time style look at Medicare drug spending</p>
+        </div>
+        <form class="controls" aria-label="Scoreboard filters">
+          <label class="control">
+            <span class="control-label">Year</span>
+            <select id="yearSelect" name="year" aria-label="Select data year"></select>
+          </label>
+          <fieldset class="control" role="radiogroup" aria-label="Medicare part">
+            <span class="control-label">Part</span>
+            <div class="segmented" id="partToggle">
+              <label>
+                <input type="radio" name="part" value="both" checked />
+                <span>Both</span>
+              </label>
+              <label>
+                <input type="radio" name="part" value="D" />
+                <span>Part D</span>
+              </label>
+              <label>
+                <input type="radio" name="part" value="B" />
+                <span>Part B</span>
+              </label>
+            </div>
+          </fieldset>
+          <label class="control toggle">
+            <input type="checkbox" id="glp1Only" />
+            <span class="control-label">Highlight GLP-1 &amp; incretin drugs</span>
+          </label>
+        </form>
+      </header>
+
+      <main class="layout" aria-live="off">
+        <section class="empty-state card" id="emptyState" role="status" hidden>
+          <h2>No data yet</h2>
+          <p>
+            Drop your CMS Medicare Part D &amp; Part B drug spending workbooks and the NHE Table 01 workbook into the
+            <code>etl/</code> script to generate JSON files. Run:
+          </p>
+          <pre class="code-block"><code>python etl/prep.py --partd "/path/to/partd.xlsx" --partb "/path/to/partb.xlsx" --nhe "/path/to/nhe_table01.xlsx"</code></pre>
+          <p>Place the emitted JSON in <code>data/</code> and refresh to light up the board.</p>
+        </section>
+
+        <section class="hero-grid" id="hero" aria-labelledby="heroTitle">
+          <article class="card hero-total">
+            <header class="card-header">
+              <h2 id="heroTitle">Estimated YTD Medicare drug spend</h2>
+            </header>
+            <div class="card-body">
+              <p class="stat-xl" id="heroTotal" data-counter>—</p>
+              <div class="hero-meta">
+                <span id="heroRate" class="hero-rate">—</span>
+                <span id="heroContext" class="hero-context"></span>
+                <span class="info-badge" tabindex="0" role="note" aria-describedby="heroTip" data-tooltip>
+                  <svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16">
+                    <circle cx="8" cy="8" r="8" />
+                    <text x="8" y="11" text-anchor="middle" font-size="10" font-family="inherit" fill="currentColor">i</text>
+                  </svg>
+                </span>
+                <span class="tooltip" id="heroTip" role="tooltip">
+                  Counters prorate the latest full-year totals across the seconds in the selected calendar year. Past years stay fixed.
+                </span>
+              </div>
+            </div>
+          </article>
+          <article class="card top-drugs" aria-labelledby="topDrugsTitle">
+            <header class="card-header">
+              <h2 id="topDrugsTitle">Top 5 drugs by spend</h2>
+            </header>
+            <div class="card-body">
+              <ol id="topDrugsList" class="top-list" aria-live="polite"></ol>
+            </div>
+          </article>
+        </section>
+
+        <section class="panels">
+          <article class="card" aria-labelledby="moversTitle">
+            <header class="card-header">
+              <h2 id="moversTitle">Big movers vs. prior year</h2>
+            </header>
+            <div class="card-body">
+              <ol id="moversList" class="movers-list"></ol>
+            </div>
+          </article>
+          <article class="card" aria-labelledby="scatterTitle">
+            <header class="card-header">
+              <h2 id="scatterTitle">Unit cost vs. volume</h2>
+            </header>
+            <div class="card-body">
+              <svg id="scatterPlot" viewBox="0 0 640 420" role="img" aria-labelledby="scatterTitle scatterDesc"></svg>
+              <p id="scatterDesc" class="visually-hidden">
+                Bubble chart comparing total Medicare drug spending per claim to total claim counts for the selected scope.
+              </p>
+            </div>
+          </article>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <div class="methods">
+          <h2>Methods &amp; scope</h2>
+          <p>
+            Medicare Part D (retail rx) + Part B (physician-admin) only; “live” counters are clean extrapolations from latest full-year totals; NHE retail rx used for contextual headline only.
+          </p>
+          <p class="footnote">
+            Data dictionary references: <a href="https://www.cms.gov/files/document/medicare-part-d-drug-data-dictionary.pdf" id="partdDict" rel="external noopener">CMS Part D dictionary</a>,
+            <a href="https://www.cms.gov/files/document/medicare-part-b-drug-data-dictionary.pdf" id="partbDict" rel="external noopener">CMS Part B dictionary</a>. NHE Table 01 local path supplied by you.
+          </p>
+        </div>
+      </footer>
+    </div>
+    <div id="tooltip" class="tooltip-layer" role="presentation" hidden></div>
+  </body>
+</html>

--- a/rx-scoreboard/style.css
+++ b/rx-scoreboard/style.css
@@ -1,0 +1,577 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f7fb;
+  --card-bg: rgba(255, 255, 255, 0.85);
+  --text: #0a1f33;
+  --muted: #44566c;
+  --accent: #2b7fff;
+  --accent-strong: #1557b5;
+  --part-d: #2b7fff;
+  --part-b: #ff9f0f;
+  --glp1: #2fbf9c;
+  --border: rgba(12, 39, 66, 0.08);
+  --shadow: 0 18px 40px rgba(9, 32, 55, 0.12);
+  --radius: 24px;
+  --focus: #ff9f0f;
+  --stat-font: 'SF Pro Display', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117;
+    --card-bg: rgba(22, 27, 34, 0.92);
+    --text: #f3f5f8;
+    --muted: #b0bdd1;
+    --accent: #65a9ff;
+    --accent-strong: #8bc0ff;
+    --part-d: #65a9ff;
+    --part-b: #ffb755;
+    --glp1: #6be5c3;
+    --border: rgba(255, 255, 255, 0.08);
+    --shadow: 0 18px 36px rgba(0, 0, 0, 0.5);
+    --focus: #ffdd57;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(120% 120% at 20% 20%, rgba(43, 127, 255, 0.12), transparent),
+    radial-gradient(120% 120% at 80% 0%, rgba(255, 159, 15, 0.12), transparent), var(--bg);
+  display: flex;
+  justify-content: center;
+  padding: clamp(1.5rem, 3vw, 3rem);
+  color: var(--text);
+}
+
+body, select, input, button {
+  font-family: inherit;
+  font-size: 1rem;
+}
+
+.app-shell {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2vw, 2.5rem);
+}
+
+.site-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 2vw, 2rem);
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+  position: sticky;
+  top: clamp(1rem, 2vw, 2rem);
+  backdrop-filter: blur(18px);
+  z-index: 2;
+}
+
+.brand h1 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  align-items: end;
+}
+
+.control {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.control-label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+select,
+input[type="text"],
+input[type="number"],
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: var(--accent);
+}
+
+select {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--card-bg) 95%, transparent);
+  color: var(--text);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.segmented {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  background: color-mix(in srgb, var(--card-bg) 90%, transparent);
+}
+
+.segmented label {
+  position: relative;
+}
+
+.segmented input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.segmented span {
+  display: block;
+  text-align: center;
+  padding: 0.55rem 0.4rem;
+  font-weight: 600;
+  color: var(--muted);
+  transition: background 180ms ease, color 180ms ease;
+}
+
+.segmented input:checked + span {
+  background: var(--accent);
+  color: #fff;
+}
+
+.toggle {
+  align-items: center;
+  grid-auto-flow: column;
+  grid-template-columns: auto 1fr;
+  gap: 0.6rem;
+}
+
+.toggle input[type="checkbox"] {
+  width: 42px;
+  height: 24px;
+  appearance: none;
+  border-radius: 999px;
+  position: relative;
+  background: color-mix(in srgb, var(--muted) 40%, transparent);
+  transition: background 200ms ease;
+}
+
+.toggle input[type="checkbox"]::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 200ms ease;
+}
+
+.toggle input[type="checkbox"]:checked {
+  background: var(--accent);
+}
+
+.toggle input[type="checkbox"]:checked::after {
+  transform: translateX(16px);
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2vw, 2.5rem);
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+  overflow: hidden;
+}
+
+.card-header {
+  padding: 1.25rem 1.5rem 0.75rem;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: clamp(1.2rem, 2vw, 1.5rem);
+}
+
+.card-body {
+  padding: 0 1.5rem 1.5rem;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+}
+
+.empty-state h2 {
+  margin-top: 0;
+}
+
+.empty-state p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.stat-xl {
+  font-family: var(--stat-font);
+  font-size: clamp(3.5rem, 10vw, 6.5rem);
+  margin: 0;
+  letter-spacing: -0.04em;
+}
+
+.hero-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+  flex-wrap: wrap;
+}
+
+.hero-rate {
+  font-weight: 600;
+}
+
+.hero-context {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.info-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
+  cursor: help;
+  position: relative;
+}
+
+.info-badge svg circle {
+  fill: currentColor;
+  opacity: 0.12;
+}
+
+.info-badge svg text {
+  fill: currentColor;
+}
+
+.tooltip {
+  position: absolute;
+  transform: translateY(8px);
+  background: var(--text);
+  color: var(--bg);
+  padding: 0.6rem 0.8rem;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+  max-width: 240px;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.info-badge:focus + .tooltip,
+.info-badge:hover + .tooltip {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.top-list,
+.movers-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.top-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.6rem 0.2rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  flex-wrap: wrap;
+}
+
+.top-list li:last-child {
+  border-bottom: none;
+}
+
+.top-list .drug-name {
+  font-weight: 600;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.top-list .drug-value {
+  font-family: var(--stat-font);
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  display: block;
+}
+
+.drug-metrics {
+  text-align: right;
+  min-width: 160px;
+}
+
+.drug-metrics small {
+  display: block;
+}
+
+.top-list .drug-rate {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.pill.part-d {
+  background: rgba(43, 127, 255, 0.16);
+  color: var(--part-d);
+}
+
+.pill.part-b {
+  background: rgba(255, 159, 15, 0.16);
+  color: var(--part-b);
+}
+
+.pill.glp1 {
+  background: rgba(47, 191, 156, 0.18);
+  color: var(--glp1);
+}
+
+.movers-list li {
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.movers-list li:last-child {
+  border-bottom: none;
+}
+
+.movers-list .row-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.movers-list .row-top .name {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.movers-list .row-bottom {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.movers-list .row-top .pill {
+  margin-right: 0.35rem;
+}
+
+.delta-badge {
+  background: rgba(43, 127, 255, 0.16);
+  color: var(--accent-strong);
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+#scatterPlot {
+  width: 100%;
+  height: auto;
+}
+
+#scatterPlot circle {
+  cursor: pointer;
+}
+
+#scatterPlot circle:focus-visible {
+  stroke: var(--focus);
+  stroke-width: 3;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-footer {
+  background: transparent;
+  padding-bottom: 2rem;
+}
+
+.methods {
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+}
+
+.methods h2 {
+  margin-top: 0;
+  font-size: clamp(1.1rem, 2vw, 1.4rem);
+}
+
+.methods p {
+  margin: 0.8rem 0;
+  line-height: 1.5;
+}
+
+.methods a {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.methods a:hover,
+.methods a:focus-visible {
+  text-decoration: underline;
+}
+
+.footnote {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.noscript {
+  background: #fff1f0;
+  color: #a61b00;
+  padding: 1rem;
+  text-align: center;
+}
+
+.code-block {
+  padding: 0.75rem;
+  background: color-mix(in srgb, var(--card-bg) 85%, transparent);
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+.tooltip-layer {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  font-size: 0.85rem;
+  z-index: 10;
+}
+
+.tooltip-layer .bubble {
+  position: absolute;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  background: var(--text);
+  color: var(--bg);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.28);
+  max-width: 260px;
+  line-height: 1.45;
+}
+
+.tooltip-layer .bubble strong {
+  display: block;
+  font-size: 0.9rem;
+  margin-bottom: 0.35rem;
+}
+
+:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 4px;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1rem;
+  }
+  .site-header {
+    position: static;
+  }
+  .segmented {
+    grid-template-columns: repeat(3, minmax(0, auto));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add the self-contained `rx-scoreboard` static experience with responsive layout, live-style counters, filtering controls, and accessibility features
- implement a Python ETL pipeline that normalizes CMS Part B/D workbooks plus NHE Table 01 into the required JSON contract
- document setup steps, data requirements, and troubleshooting guidance

## Testing
- python3 -m py_compile rx-scoreboard/etl/prep.py

------
https://chatgpt.com/codex/tasks/task_e_68cabc766ff88320b3084b36f866798b